### PR TITLE
Fix bug where waste_structure is improperly deserialized

### DIFF
--- a/bot/definition.cpp
+++ b/bot/definition.cpp
@@ -38,8 +38,8 @@ void weight::set(const std::string & file_path)
 	this->burn_2 = js["burn_2"];
 	this->burn_3 = js["burn_3"];
 	this->waste_time = js["waste_time"];
-	for (int i = 0; i < 3; ++i) {
-		this->waste_structure[0] = js["waste_structure"][0];
+	for (int i = 0; i < 2; ++i) {
+		this->waste_structure[i] = js["waste_structure"][i];
 	}
 	this->waste_T = js["waste_T"];
 	this->waste_I = js["waste_I"];

--- a/sfml-example/Type.h
+++ b/sfml-example/Type.h
@@ -69,8 +69,8 @@ static void set_weight_js(weight & w, json js, int player) {
 	w.burn_2 = js[plr]["burn_2"];
 	w.burn_3 = js[plr]["burn_3"];
 	w.waste_time = js[plr]["waste_time"];
-	for (int i = 0; i < 3; ++i) {
-		w.waste_structure[0] = js[plr]["waste_structure"][0];
+	for (int i = 0; i < 2; ++i) {
+		w.waste_structure[i] = js[plr]["waste_structure"][i];
 	}
 	w.waste_T = js[plr]["waste_T"];
 	w.waste_I = js[plr]["waste_I"];


### PR DESCRIPTION
`waste_structure`s deserialization only copied the first element of the array over, which does not seem intended. One thing to also consider is turning `waste_structure` into a `std::array<int, 2>` instead of a C style array. This way, one may use C++ methods to get the length of the array and reduce duplicated constants.